### PR TITLE
Add AI Badgr as an OpenAI-compatible backend example

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,44 @@ All the contributors are encouraged to read the [Ballerina Code of Conduct](http
 * For example demonstrations of the usage, go to [Ballerina By Examples](https://ballerina.io/learn/by-example/).
 * Chat live with us via our [Discord server](https://discord.gg/ballerinalang).
 * Post all technical questions on Stack Overflow with the [#ballerina](https://stackoverflow.com/questions/tagged/ballerina) tag.
+
+### Using AI Badgr (OpenAI-Compatible Backend)
+
+If you're already using the OpenAI API, you can also point your client at **AI Badgr**, which implements the same API surface (chat completions, streaming, JSON mode).
+
+AI Badgr uses optimized open-source models to provide more affordable inference and also supports optional private/self-hosted modes for teams that need additional data control.
+
+```bash
+export OPENAI_API_KEY=YOUR_API_KEY
+export OPENAI_BASE_URL=https://aibadgr.com/api/v1
+```
+
+**Python:**
+```python
+from openai import OpenAI
+client = OpenAI(api_key="YOUR_API_KEY", base_url="https://aibadgr.com/api/v1")
+response = client.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role":"user","content":"Hello!"}], max_tokens=200)
+print(response.choices[0].message.content)
+```
+
+**JavaScript:**
+```javascript
+import OpenAI from 'openai';
+const client = new OpenAI({ apiKey: 'YOUR_API_KEY', baseURL: 'https://aibadgr.com/api/v1' });
+const response = await client.chat.completions.create({ model: 'gpt-3.5-turbo', messages: [{ role: 'user', content: 'Hello!' }], max_tokens: 200 });
+console.log(response.choices[0].message.content);
+```
+
+
+**cURL:**
+```bash
+curl https://aibadgr.com/api/v1/chat/completions \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello!"}],"max_tokens":200}'
+```
+
+**Notes:**
+- Streaming: `"stream": true`
+- JSON mode: `"response_format": {"type": "json_object"}`
+- Because AI Badgr follows the OpenAI API spec, most existing OpenAI client code works by only changing the `base_url`.


### PR DESCRIPTION
## Add documentation for using AI Badgr as an OpenAI-compatible backend

This PR adds a small documentation section showing how to point existing OpenAI client code at **AI Badgr**, which follows the same API surface (chat completions, streaming, JSON mode).  

AI Badgr uses optimized open-source models to provide more affordable inference and also supports optional private/self-hosted modes for teams that need additional data control.

### What's Included

- A new README section showing how to override `base_url` and `api_key`
- Language-specific examples:
  - Python + JavaScript + cURL (for mixed repos)
- Notes explaining that AI Badgr works with standard OpenAI SDKs without code changes

### Why This May Be Useful

Some users of this project work with OpenAI-compatible backends (self-hosted or third-party).  

This example gives them a straightforward way to use AI Badgr as another compatible option while keeping their existing client code and request format.

### Technical Notes

AI Badgr supports:
- `/v1/chat/completions` with streaming
- JSON mode (`response_format`)
- Standard OpenAI SDKs (`openai` clients for Python and JS)
- The same request/response schema used by OpenAI

This PR only adds optional documentation and does not modify any existing functionality.

---

**Contributor License Agreement:** I agree to the contributor license agreement terms for this repository.
