### PR TITLE
Clarify Overview so the Central summary distinguishes openai.chat

### DIFF
--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -1,8 +1,6 @@
 ## Overview
 
-[OpenAI](https://openai.com/), an AI research organization focused on creating friendly AI for humanity, offers the [OpenAI API](https://platform.openai.com/docs/api-reference/introduction) to access its powerful AI models for tasks like natural language processing and image generation.
-
-The `ballerinax/openai.chat` package offers functionality to connect and interact with the [Chat Completions endpoint of the OpenAI REST API](https://platform.openai.com/docs/api-reference/chat/create). This enables seamless integration with OpenAI's chat models for conversational and text generation tasks.
+The `openai.chat` module is a direct, fully-typed REST connector for OpenAI's [Chat Completions API](https://platform.openai.com/docs/api-reference/chat) (`POST /chat/completions`). Use it as a standalone client to send chat prompts to GPT models (GPT-4o, GPT-4, GPT-3.5) and receive completions with full control over request parameters such as tools, temperature, and structured response formats — independent of the `ballerina/ai` agent framework.
 
 
 ### Key Features

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -1,8 +1,6 @@
 ## Overview
 
-[OpenAI](https://openai.com/) offers powerful AI models for tasks like natural language processing, audio transcription, and image generation.
-
-The OpenAI Chat connector offers APIs to connect and interact with the chat completion related endpoints of the OpenAI REST API, enabling seamless interaction with advanced GPT models for diverse conversational and text generation tasks.
+The `openai.chat` module is a direct, fully-typed REST connector for OpenAI's [Chat Completions API](https://platform.openai.com/docs/api-reference/chat) (`POST /chat/completions`). Use it as a standalone client to send chat prompts to GPT models (GPT-4o, GPT-4, GPT-3.5) and receive completions with full control over request parameters such as tools, temperature, and structured response formats — independent of the `ballerina/ai` agent framework.
 
 ### Key Features
 - Integration with advanced GPT models including GPT-4o, GPT-4, and GPT-3.5


### PR DESCRIPTION
### Purpose

The first paragraph of the package Overview is what Ballerina Central stores as the package **summary**, and that summary is the `description` the Ballerina Copilot **library-search tool** returns to the agent when it picks a library. Today `openai.chat` and the `ai.openai` model provider both open with a generic OpenAI vendor blurb, so their summaries are nearly identical and an agent cannot tell them apart.

### Change

Rewrite the Overview's first paragraph to state what this module uniquely is — a **direct, fully-typed REST connector for OpenAI's Chat Completions API** (`POST /chat/completions`), independent of the `ballerina/ai` agent framework — and merge away the now-redundant generic second paragraph. Applied to **both** `ballerina/Package.md` and `ballerina/Module.md` so the package doc and module doc stay in sync. **Key Features** and everything below are untouched.

Grounded in the actual API (`Client` with `resource post chat/completions(CreateChatCompletionRequest) → CreateChatCompletionResponse`).

> Draft: opening for review of wording before finalizing. Part of a wider pass to disambiguate OpenAI-related package summaries (`openai.chat` vs `ai.openai`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)